### PR TITLE
Add smoothBlink option

### DIFF
--- a/README.md~
+++ b/README.md~
@@ -45,7 +45,6 @@ Options
  prefix               | `""` (string)                       | Begin each string with this prefix value.
  loop                 | `0` (int)                           | Number of times to loop through the output strings, for unlimited use `0`.
  humanise             | `true` (boolean)                    | Add a random delay before each character to represent human interaction.
- smoothBlink          | `true` (boolean)                    | Set the curser to a solid blink or smooth blink effect.                | 
  callbackNext         | `null` (function)                   | Callback function called every text item. See `Callback functions` below.
  callbackType         | `null` (function)                   | Callback function called every 'letter'. See `Callback functions` below.
  callbackFinished     | `null` (function)                   | Callback function called once everything is finished. See `Callback functions` below.

--- a/jquery.teletype.js
+++ b/jquery.teletype.js
@@ -141,7 +141,11 @@
 					.appendTo( self );
 				object.setCursor( settings.cursor );
 				setInterval ( function() {
-					cursor.animate( { opacity: 0 } ).animate( { opacity: 1 } );
+                  if ( settings.smoothBlink ) {
+				    cursor.animate( { opacity: 0 } ).animate( { opacity: 1 } );
+			      } else {
+                      cursor.delay(500).fadeTo(0,0).delay(500).fadeTo(0,1);
+                  }
 				}, settings.blinkSpeed );
 			}
 			type();
@@ -158,6 +162,7 @@
 		prefix: '',
 		loop: 0,
 		humanise: true,
+		smoothBlink: true,
 		callbackNext: null,
 		callbackType: null,
 		callbackFinished: null


### PR DESCRIPTION
Hi, I added an option called smoothBlink which is enabled by default. If you want to have a solid blink (without a smooth transition) all you need to do is change smoothBlink to false. I also updated the README to include this option.
