### PR TITLE
Add callbackFinished to backspace function

### DIFF
--- a/jquery.teletype.js
+++ b/jquery.teletype.js
@@ -112,6 +112,9 @@
 			} else {
 				if ( stop === 0 ) {
 					if ( next() === false ) {
+						if ( typeof( settings.callbackFinished ) == 'function' ) {
+							settings.callbackFinished( object );
+						}
 						return;
 					}
 				}


### PR DESCRIPTION
If we add a 'done' check, as in typing function, to backspace function too, then typing-completed callback fires in both preserve and backspace modes.